### PR TITLE
fixed correct return type for soap::__doRequest()

### DIFF
--- a/vendor/Integrations/phpsdk-package/src/Soap.php
+++ b/vendor/Integrations/phpsdk-package/src/Soap.php
@@ -366,8 +366,7 @@ class Soap extends \SoapClient
      * @return mixed|string
      * @throws TurnitinSDKException
      */
-    public function __doRequest($request, $location, $action, $version, $one_way = null)
-    {
+    public function __doRequest($request, $location, $action, $version, $one_way = null): ?string {
 
         $http_headers = array(
             'Content-type: text/xml;charset="utf-8"',


### PR DESCRIPTION
PHP 8.1 requires methods to declare the same return type as their parents. This fixes a PHP 8.1 warning. 